### PR TITLE
fix : docker-compose 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: ${ROOT_PASSWORD}
     restart: on-failure
     volumes:
-      - mongodb_data:/var/lib/mongodb  # 데이터를 저장할 볼륨 정의
+      - mongodb-volume:/data/db # 데이터를 저장할 볼륨 정의
 
 
   # Spring Boot 서비스 정의


### PR DESCRIPTION
몽고 DB 스타일로 docker-compose안의 볼륨 이름을 다시 정의했습니다.

#### 변경 전
```kotlin
mongodb_data:/var/lib/mongodb  # 데이터를 저장할 볼륨 정의
```

#### 변경 후
```kotlin
mongodb-volume:/data/db # 데이터를 저장할 볼륨 정의
```