### PR TITLE
refactor(auth): 예외 처리 개선 및 인증 코드 유효시간 변경

### DIFF
--- a/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
@@ -14,6 +14,7 @@ import com.example.solo_play_web_server.auth.repository.PendingMemberRepository
 import com.example.solo_play_web_server.common.auth.JwtProvider
 import com.example.solo_play_web_server.common.exception.EmailDuplicateException
 import com.example.solo_play_web_server.common.exception.InvalidTokenException
+import com.example.solo_play_web_server.common.exception.LoginFailedException
 import com.example.solo_play_web_server.common.exception.NicknameDuplicateException
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
@@ -32,10 +33,10 @@ class MemberService (
 ){
     suspend fun requestSignUp(signUpRequest: SignUpRequest) {
         if(memberRepository.existsByEmail(signUpRequest.email).awaitSingle()){
-            throw EmailDuplicateException()
+            throw EmailDuplicateException(message = "이미 사용 중인 이메일입니다.")
         }
         if(memberRepository.existsByNickname(signUpRequest.nickname).awaitSingle()){
-            throw NicknameDuplicateException()
+            throw NicknameDuplicateException(message = "이미 사용 중인 닉네임입니다.")
         }
 
         val code = String.format("%06d", Random().nextInt(1_000_000))
@@ -62,7 +63,7 @@ class MemberService (
             ?: throw InvalidTokenException("인증 시간이 만료되었거나 요청 정보가 잘못되었습니다.")
 
         if(verificationData.code != sendVerifyEmailRequest.code){
-            throw InvalidTokenException("인증 코드가 일치하지 않습니다.")
+            throw InvalidTokenException("인증코드가 틀렸습니다.")
         }
 
         pendingMemberRepository.deleteByEmail(sendVerifyEmailRequest.email)
@@ -84,10 +85,10 @@ class MemberService (
 
     suspend fun login(loginRequest: LoginRequest) : TokenResponse {
         val member = memberRepository.findByEmail(loginRequest.email).awaitSingleOrNull()
-            ?: throw IllegalArgumentException("가입되지 않은 이메일입니다.")
+            ?: throw LoginFailedException("존재하지 않는 계정입니다. 회원가입 하시겠습니까?")
 
         if (!passwordEncoder.matches(loginRequest.password, member.password)) {
-            throw IllegalArgumentException("비밀번호가 일치하지 않습니다.")
+            throw LoginFailedException("사용자 이름 또는 비밀번호가 올바르지 않습니다.")
         }
 
         return jwtProvider.generateTokens(member.id!!, member.role)

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
@@ -48,7 +48,7 @@ class MemberService (
 
         val verificationData = VerificationData(pendingMember, code)
 
-        val success = pendingMemberRepository.save(signUpRequest.email, verificationData, Duration.ofMinutes(15))
+        val success = pendingMemberRepository.save(signUpRequest.email, verificationData, Duration.ofMinutes(10))
 
         if(success) {
             emailService.sendVerificationCode(signUpRequest.email, code)

--- a/src/main/kotlin/com/example/solo_play_web_server/common/exception/BusinessException.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/common/exception/BusinessException.kt
@@ -3,7 +3,7 @@ package com.example.solo_play_web_server.common.exception
 open class BusinessException(override val message: String) : RuntimeException(message)
 
 // 실제 예외 클래스들
-class EmailDuplicateException(message: String = "이미 사용 중인 이메일입니다.") : BusinessException(message)
-class NicknameDuplicateException(message: String = "이미 사용 중인 닉네임입니다.") : BusinessException(message)
-class LoginFailedException(message: String = "가입되지 않은 이메일이거나, 비밀번호가 올바르지 않습니다.") : BusinessException(message)
+class EmailDuplicateException(message: String) : BusinessException(message)
+class NicknameDuplicateException(message: String) : BusinessException(message)
+class LoginFailedException(message: String) : BusinessException(message)
 class InvalidTokenException(message: String) : BusinessException(message)

--- a/src/main/resources/templates/verificationCodeEmail.html
+++ b/src/main/resources/templates/verificationCodeEmail.html
@@ -37,7 +37,7 @@
                         </div>
 
                         <p style="margin: 0; font-size: 14px; color: #868e96;">
-                            이 인증 코드는 <strong style="color: #d9480f;">15분</strong>간 유효합니다.<br>
+                            이 인증 코드는 <strong style="color: #d9480f;">10분</strong>간 유효합니다.<br>
                             만약 본인이 요청한 것이 아니라면 이 메일을 무시해주세요.
                         </p>
                     </td>

--- a/src/test/kotlin/com/example/solo_play_web_server/place/MemberServiceSpec.kt
+++ b/src/test/kotlin/com/example/solo_play_web_server/place/MemberServiceSpec.kt
@@ -17,6 +17,7 @@ import com.example.solo_play_web_server.auth.service.MemberService
 import com.example.solo_play_web_server.common.auth.JwtProvider
 import com.example.solo_play_web_server.common.exception.EmailDuplicateException
 import com.example.solo_play_web_server.common.exception.InvalidTokenException
+import com.example.solo_play_web_server.common.exception.LoginFailedException
 import com.example.solo_play_web_server.common.exception.NicknameDuplicateException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -82,9 +83,10 @@ class MemberServiceSpec : BehaviorSpec (){
                 coEvery { memberRepository.existsByEmail(signUpRequest.email) } returns Mono.just(true)
 
                 Then("EmailDuplicateException 예외가 발생한다.") {
-                    shouldThrow<EmailDuplicateException>{
+                    val exception = shouldThrow<EmailDuplicateException>{
                         memberService.requestSignUp(signUpRequest)
                     }
+                    exception.message shouldBe "이미 사용 중인 이메일입니다."
                 }
             }
 
@@ -93,9 +95,10 @@ class MemberServiceSpec : BehaviorSpec (){
                 coEvery { memberRepository.existsByNickname(any()) } returns Mono.just(true)
 
                 Then("NickNameDuplicateException 예외가 발생한다."){
-                    shouldThrow<NicknameDuplicateException> {
+                    val exception = shouldThrow<NicknameDuplicateException> {
                         memberService.requestSignUp(signUpRequest)
                     }
+                    exception.message shouldBe "이미 사용 중인 닉네임입니다."
                 }
             }
 
@@ -146,9 +149,10 @@ class MemberServiceSpec : BehaviorSpec (){
                 coEvery { pendingMemberRepository.findByEmail(request.email) } returns wrongVerificationData
 
                 Then("InvalidTokenException 예외가 발생한다."){
-                    shouldThrow<InvalidTokenException> {
+                    val exception = shouldThrow<InvalidTokenException> {
                         memberService.verifyCodeAndSignUp(request)
                     }
+                    exception.message shouldBe "인증코드가 틀렸습니다."
                 }
             }
 
@@ -156,9 +160,10 @@ class MemberServiceSpec : BehaviorSpec (){
                 coEvery { pendingMemberRepository.findByEmail(request.email) } returns null
 
                 Then("InvalidTokenException 예외가 발생한다") {
-                    shouldThrow<InvalidTokenException> {
+                    val exception = shouldThrow<InvalidTokenException> {
                         memberService.verifyCodeAndSignUp(request)
                     }
+                    exception.message shouldBe "인증 시간이 만료되었거나 요청 정보가 잘못되었습니다."
                 }
             }
         }
@@ -185,10 +190,11 @@ class MemberServiceSpec : BehaviorSpec (){
             When("가입되지 않은 이메일로 요청하면"){
                 coEvery { memberRepository.findByEmail(loginRequest.email) } returns Mono.empty()
 
-                Then("IllegalArgumentException 예외가 발생한다."){
-                    shouldThrow<IllegalArgumentException> {
+                Then("LoginFailedException 예외가 발생한다."){
+                    val exception = shouldThrow<LoginFailedException> {
                         memberService.login(loginRequest)
                     }
+                    exception.message shouldBe "존재하지 않는 계정입니다. 회원가입 하시겠습니까?"
                 }
             }
 
@@ -196,10 +202,11 @@ class MemberServiceSpec : BehaviorSpec (){
                 coEvery { memberRepository.findByEmail(loginRequest.email) } returns Mono.just(member)
                 every { passwordEncoder.matches(loginRequest.password, member.password) } returns false
 
-                Then("IllegalArgumentException 예외가 발생한다."){
-                    shouldThrow<IllegalArgumentException> {
+                Then("LoginFailedException 예외가 발생한다."){
+                    val exception = shouldThrow<LoginFailedException> {
                         memberService.login(loginRequest)
                     }
+                    exception.message shouldBe "사용자 이름 또는 비밀번호가 올바르지 않습니다."
                 }
             }
         }

--- a/src/test/kotlin/com/example/solo_play_web_server/place/MemberServiceSpec.kt
+++ b/src/test/kotlin/com/example/solo_play_web_server/place/MemberServiceSpec.kt
@@ -1,0 +1,209 @@
+package com.example.solo_play_web_server.place
+
+import com.example.solo_play_web_server.auth.dto.Agreement
+import com.example.solo_play_web_server.auth.dto.LoginRequest
+import com.example.solo_play_web_server.auth.dto.PendingMember
+import com.example.solo_play_web_server.auth.dto.SendVerifyEmailRequest
+import com.example.solo_play_web_server.auth.dto.SignUpRequest
+import com.example.solo_play_web_server.auth.dto.TokenResponse
+import com.example.solo_play_web_server.auth.dto.VerificationData
+import com.example.solo_play_web_server.auth.entity.Member
+import com.example.solo_play_web_server.auth.enum.AuthProvider
+import com.example.solo_play_web_server.auth.enum.MemberRole
+import com.example.solo_play_web_server.auth.repository.MemberRepository
+import com.example.solo_play_web_server.auth.repository.PendingMemberRepository
+import com.example.solo_play_web_server.auth.service.EmailService
+import com.example.solo_play_web_server.auth.service.MemberService
+import com.example.solo_play_web_server.common.auth.JwtProvider
+import com.example.solo_play_web_server.common.exception.EmailDuplicateException
+import com.example.solo_play_web_server.common.exception.InvalidTokenException
+import com.example.solo_play_web_server.common.exception.NicknameDuplicateException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import org.springframework.security.crypto.password.PasswordEncoder
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+class MemberServiceSpec : BehaviorSpec (){
+    @MockK
+    lateinit var memberRepository: MemberRepository
+    @MockK
+    lateinit var passwordEncoder: PasswordEncoder
+    @MockK
+    lateinit var pendingMemberRepository: PendingMemberRepository
+    @MockK
+    lateinit var emailService: EmailService
+    @MockK
+    lateinit var jwtProvider: JwtProvider
+    @InjectMockKs
+    lateinit var memberService: MemberService
+
+    init {
+        beforeSpec {
+            MockKAnnotations.init(this)
+        }
+
+        afterTest {
+            clearAllMocks()
+        }
+
+        Given("회원가입 요청(requestSignUp) 시") {
+            val signUpRequest = SignUpRequest(
+                email = "test@example.com",
+                password = "password123",
+                nickname = "tester",
+                agreement = Agreement(true, true, true, true)
+            )
+
+            When("정상적인 정보로 요청하면") {
+                coEvery { memberRepository.existsByEmail(any()) } returns Mono.just(false)
+                coEvery { memberRepository.existsByNickname(any()) } returns Mono.just(false)
+                every { passwordEncoder.encode(any()) } returns "encoderPassword"
+                coEvery { pendingMemberRepository.save(any(), any(), any()) } returns true
+                coEvery { emailService.sendVerificationCode(any(), any()) } returns Unit
+
+                memberService.requestSignUp(signUpRequest)
+
+                Then("임시 회원 정보가 저장되고 인증 메일이 발송된다.") {
+                    coVerify(exactly = 1) { pendingMemberRepository.save(signUpRequest.email, any(), Duration.ofMinutes(10)) }
+                    coVerify(exactly = 1) { emailService.sendVerificationCode(signUpRequest.email, any()) }
+                }
+            }
+
+            When("이미 사용 중인 이메일로 요청하면"){
+                coEvery { memberRepository.existsByEmail(signUpRequest.email) } returns Mono.just(true)
+
+                Then("EmailDuplicateException 예외가 발생한다.") {
+                    shouldThrow<EmailDuplicateException>{
+                        memberService.requestSignUp(signUpRequest)
+                    }
+                }
+            }
+
+            When("이미 사용 중인 닉네임으로 요청하면"){
+                coEvery { memberRepository.existsByEmail(any()) } returns Mono.just(false)
+                coEvery { memberRepository.existsByNickname(any()) } returns Mono.just(true)
+
+                Then("NickNameDuplicateException 예외가 발생한다."){
+                    shouldThrow<NicknameDuplicateException> {
+                        memberService.requestSignUp(signUpRequest)
+                    }
+                }
+            }
+
+            When("임시 회원 정보 저장에 실패하면") {
+                coEvery { memberRepository.existsByEmail(any()) } returns Mono.just(false)
+                coEvery { memberRepository.existsByNickname(any()) } returns Mono.just(false)
+                every { passwordEncoder.encode(any()) } returns "encodedPassword"
+                coEvery { pendingMemberRepository.save(any(), any(), any()) } returns false
+
+                Then("RuntimeException 예외가 발생하고 이메일은 발송되지 않는다") {
+                    val exception = shouldThrow<RuntimeException> {
+                        memberService.requestSignUp(signUpRequest)
+                    }
+                    exception.message shouldBe "임시 회원 저장에 실패했습니다."
+
+                    coVerify(exactly = 0) { emailService.sendVerificationCode(any(), any()) }
+                }
+            }
+        }
+
+        Given("인증 및 회원가입(verifyCodeAndSignUp) 시"){
+            val request = SendVerifyEmailRequest("test@example.com", "123456")
+            val pendingMember = PendingMember("test@example.com", "encodedPassword", "tester", Agreement(true, true, true, true))
+            val verificationData = VerificationData(pendingMember, "123456")
+            val savedMember = Member("id","test@example.com", "encodedPassword", "tester",
+                null, AuthProvider.LOCAL, setOf(MemberRole.USER),
+                Agreement(true, true, true, true), true)
+            val tokenResponse = TokenResponse("Bearer","accessToken", "refreshToken")
+
+
+            When("올바른 인증 코드로 요청하면"){
+                coEvery { pendingMemberRepository.findByEmail(request.email) } returns verificationData
+                coEvery { pendingMemberRepository.deleteByEmail(request.email) } returns Unit
+                coEvery { memberRepository.save(any()) } returns Mono.just(savedMember)
+                every { jwtProvider.generateTokens(savedMember.id!!, savedMember.role) } returns tokenResponse
+
+                val result = memberService.verifyCodeAndSignUp(request)
+
+                Then("회원가입이 완료되고 토큰이 발급된다."){
+                    result shouldBe tokenResponse
+                    coVerify(exactly = 1) { memberRepository.save(any()) }
+                    coVerify(exactly = 1) { pendingMemberRepository.deleteByEmail(request.email) }
+                }
+            }
+
+            When("인증 코드가 일치하지 않으면"){
+                val wrongVerificationData = verificationData.copy(code = "654321")
+                coEvery { pendingMemberRepository.findByEmail(request.email) } returns wrongVerificationData
+
+                Then("InvalidTokenException 예외가 발생한다."){
+                    shouldThrow<InvalidTokenException> {
+                        memberService.verifyCodeAndSignUp(request)
+                    }
+                }
+            }
+
+            When("인증 코드의 유효시간이 지나면"){
+                coEvery { pendingMemberRepository.findByEmail(request.email) } returns null
+
+                Then("InvalidTokenException 예외가 발생한다") {
+                    shouldThrow<InvalidTokenException> {
+                        memberService.verifyCodeAndSignUp(request)
+                    }
+                }
+            }
+        }
+
+        Given("로그인(login) 시"){
+            val loginRequest = LoginRequest("test@example.com", "password123")
+            val member = Member("id", "test@example.com", "encodedPassword", "tester",
+                null, AuthProvider.LOCAL, setOf(MemberRole.USER),
+                Agreement(true, true, true, true), true)
+            val tokenResponse = TokenResponse("Bearer", "accessToken", "refreshToken")
+
+            When("올바른 이메일과 비밀번호로 요청하면"){
+                coEvery { memberRepository.findByEmail(loginRequest.email) } returns Mono.just(member)
+                every { passwordEncoder.matches(loginRequest.password, member.password) } returns true
+                every { jwtProvider.generateTokens(member.id!!, member.role) } returns tokenResponse
+
+                val result = memberService.login(loginRequest)
+
+                Then("성공적으로 로그인이되고 토큰이 발급된다."){
+                    result shouldBe tokenResponse
+                }
+            }
+
+            When("가입되지 않은 이메일로 요청하면"){
+                coEvery { memberRepository.findByEmail(loginRequest.email) } returns Mono.empty()
+
+                Then("IllegalArgumentException 예외가 발생한다."){
+                    shouldThrow<IllegalArgumentException> {
+                        memberService.login(loginRequest)
+                    }
+                }
+            }
+
+            When("비밀번호가 일치하지 않으면"){
+                coEvery { memberRepository.findByEmail(loginRequest.email) } returns Mono.just(member)
+                every { passwordEncoder.matches(loginRequest.password, member.password) } returns false
+
+                Then("IllegalArgumentException 예외가 발생한다."){
+                    shouldThrow<IllegalArgumentException> {
+                        memberService.login(loginRequest)
+                    }
+                }
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
### Description

이번 변경은 회원 인증/인가(Auth) 파트의 안정성과 보안을 강화하기 위한 두 가지 주요 개선 작업을 포함합니다.

1.  **예외 처리 리팩토링**: 제네릭 예외를 도메인 특화 커스텀 예외로 변경하여 에러 핸들링을 정교화하고, 사용자에게 더 친절한 피드백을 제공하도록 개선했습니다.
2.  **인증 코드 유효시간 단축**: 회원가입 시 사용되는 이메일 인증 코드의 만료 시간을 기존 15분에서 10분으로 단축하여 보안을 강화했습니다.

### Changes

#### 1. 예외 처리 리팩토링
- **로그인 실패 예외 변경**:
  - `IllegalArgumentException`을 `LoginFailedException` 커스텀 예외로 교체하여 로그인 실패 상황을 명확하게 처리하도록 변경했습니다.
  
```kotlin
suspend fun login(loginRequest: LoginRequest) : TokenResponse {
    val member = memberRepository.findByEmail(loginRequest.email).awaitSingleOrNull()
        ?: throw IllegalArgumentException("가입되지 않은 이메일입니다.")
        //change
        ?: throw LoginFailedException("존재하지 않는 계정입니다. 회원가입 하시겠습니까?")

    if (!passwordEncoder.matches(loginRequest.password, member.password)) {
        throw IllegalArgumentException("비밀번호가 일치하지 않습니다.")
        //change
        throw LoginFailedException("사용자 이름 또는 비밀번호가 올바르지 않습니다.")
}
```
  
- **예외 메시지 개선**:
  - 이메일/닉네임 중복, 인증 실패 등 각 상황에 맞는 사용자 친화적인 메시지로 수정했습니다.
- **보안 강화**:
  - 로그인 실패 시 "사용자 이름 또는 비밀번호가 올바르지 않습니다." 라는 통합 메시지를 사용하여 계정 추측 공격(User Enumeration) 가능성을 줄였습니다.

#### 2. 인증 코드 유효시간 단축
- **만료 시간 변경**:
  - `MemberService`에서 임시 회원 정보를 Redis에 저장할 때의 TTL(Time To Live)을 `15분`에서 `10분`으로 변경했습니다.
  
```kotlin
val success = pendingMemberRepository.save(signUpRequest.email, verificationData, Duration.ofMinutes(15))
//change
val success = pendingMemberRepository.save(signUpRequest.email, verificationData, Duration.ofMinutes(10))
```
  
- **안내 문구 수정**:
  - 사용자에게 발송되는 이메일 템플릿(`verificationCodeEmail.html`)의 유효시간 안내 문구를 '10분'으로 수정하여 일관성을 맞추었습니다.
- **테스트 코드 수정**:
  - `MemberServiceSpec`에서 `pendingMemberRepository.save` 호출 시 유효시간이 10분으로 설정되었는지 검증하도록 테스트 케이스를 업데이트했습니다.

### Background

- **예외 처리**: 기존의 범용 예외 사용 방식은 전역 예외 핸들러(`@RestControllerAdvice`)에서 HTTP 상태 코드를 세밀하게 제어하기 어려웠습니다. 커스텀 예외를 통해 각 상황에 맞는 명확한 HTTP 응답(e.g., 400, 401, 409)을 내려줄 수 있는 기반을 마련했습니다.
- **보안**: 일회성 인증 코드의 유효 시간이 길수록 탈취 후 악용될 수 있는 시간적 위험이 증가합니다. 유효 시간을 10분으로 단축하여 보안 수준을 향상시키고자 합니다.