### PR TITLE
feat: 회원가입 API 분리 및 Redis Repository 리팩토링

### DIFF
--- a/src/main/kotlin/com/example/solo_play_web_server/auth/controller/MemberController.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/controller/MemberController.kt
@@ -2,7 +2,9 @@ package com.example.solo_play_web_server.auth.controller
 
 import com.example.solo_play_web_server.auth.dto.EmailAvailabilityResponse
 import com.example.solo_play_web_server.auth.dto.EmailVerificationRequest
+import com.example.solo_play_web_server.auth.dto.FinalizeSignUpRequest
 import com.example.solo_play_web_server.auth.dto.LoginRequest
+import com.example.solo_play_web_server.auth.dto.ProvisionalSignUpRequest
 import com.example.solo_play_web_server.auth.dto.SignUpRequest
 import com.example.solo_play_web_server.auth.dto.TokenResponse
 import com.example.solo_play_web_server.auth.service.MemberService
@@ -46,23 +48,18 @@ class MemberController(
         }
     }
 
-    @Operation(
-        summary = "[signup] 이메일 인증 코드 전송",
-        description = "회원의 이메일에 인증 메일을 발송합니다."
-    )
-    @PostMapping("/email-verify")
-    suspend fun sendVerificationEmail(@Valid @RequestBody emailVerificationRequest: EmailVerificationRequest): ResponseEntity<ApiResponse<Void>> {
-        memberService.sendVerificationCode(emailVerificationRequest)
-        return ResponseEntity.ok(ApiResponse(ResultStatus.SUCCESS,"인증 코드를 발송했습니다. 이메일을 확인해주세요."))
+    @Operation(summary = "[signup] 1. 임시 회원가입 및 이메일 인증 요청", description = "회원 정보를 받아 임시 저장하고, 해당 이메일로 인증 코드를 발송합니다.")
+    @PostMapping("/signup/provisional")
+    suspend fun provisionalSignUp(@Valid @RequestBody provisionalSignUpRequest: ProvisionalSignUpRequest): ResponseEntity<ApiResponse<Unit>> {
+        memberService.provisionalSignUp(provisionalSignUpRequest)
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse(ResultStatus.SUCCESS, "인증 메일이 발송되었습니다. 이메일을 확인해주세요."))
     }
 
-    @Operation(
-        summary = "[signup] 최종 회원가입",
-        description = "검증된 회원 정보와 이메일 인증이 성공했다면 회원가입이 성공되며 엑세스 토큰과 리프레쉬 토큰이 발급됩니다."
-    )
-    @PostMapping("/signup")
-    suspend fun signUp(@Valid @RequestBody signUpRequest: SignUpRequest): ResponseEntity<ApiResponse<TokenResponse>> {
-        val tokenResponse = memberService.signUp(signUpRequest)
+    @Operation(summary = "[signup] 2. 최종 회원가입", description = "이메일과 인증 코드로 최종 인증을 완료하고 토큰을 발급합니다.")
+    @PostMapping("/signup/finalize")
+    suspend fun finalizeSignUp(@Valid @RequestBody finalizeSignUpRequest: FinalizeSignUpRequest): ResponseEntity<ApiResponse<TokenResponse>> {
+        val tokenResponse = memberService.finalizeSignUp(finalizeSignUpRequest)
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse(ResultStatus.SUCCESS, "회원가입이 완료되었습니다.", tokenResponse))
     }

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/dto/SignUpDto.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/dto/SignUpDto.kt
@@ -43,13 +43,20 @@ data class Agreement(
     val isConsentedToAds : Boolean
 )
 
-data class PendingMember(
+data class ProvisionalSignUpRequest(
     val email: String,
     val password: String,
     val agreement: Agreement
 )
 
-data class VerificationData (
-    val pendingMember: PendingMember,
+// API #2 (최종 가입) 요청 DTO
+data class FinalizeSignUpRequest(
+    val email: String,
     val code: String
+)
+
+data class PendingMemberData(
+    val email: String,
+    val encodedPassword: String,
+    val agreement: Agreement
 )

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/repository/PendingMemberRepository.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/repository/PendingMemberRepository.kt
@@ -1,0 +1,22 @@
+package com.example.solo_play_web_server.auth.repository
+
+import com.example.solo_play_web_server.auth.dto.PendingMemberData
+import com.example.solo_play_web_server.common.repository.AbstractRedisRepository
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.stereotype.Repository
+import java.time.Duration
+
+@Repository
+class PendingMemberRepository(
+    @Qualifier("pendingMemberDataRedisTemplate")
+    override val redisTemplate: ReactiveRedisTemplate<String, PendingMemberData>
+) : AbstractRedisRepository<PendingMemberData>() {
+
+    override val keyPrefix = "PENDING_SIGNUP:"
+    private val TTL = Duration.ofMinutes(10)
+
+    suspend fun save(pendingMemberData: PendingMemberData) = save(pendingMemberData.email, pendingMemberData, TTL)
+    suspend fun findByEmail(email: String) = find(email)
+    suspend fun deleteByEmail(email: String) = delete(email)
+}

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/repository/VerificationCodeRepository.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/repository/VerificationCodeRepository.kt
@@ -1,28 +1,20 @@
 package com.example.solo_play_web_server.auth.repository
 
-import kotlinx.coroutines.reactor.awaitSingleOrNull
+import com.example.solo_play_web_server.common.repository.AbstractRedisRepository
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.stereotype.Repository
 import java.time.Duration
 
 @Repository
-class VerificationCodeRepository (
+class VerificationCodeRepository(
     @Qualifier("verificationCodeRedisTemplate")
-    private val redisTemplate: ReactiveRedisTemplate<String, String>
-){
-    private fun getKey(email: String) = "verificationCode:$email"
+    override val redisTemplate: ReactiveRedisTemplate<String, String>
+) : AbstractRedisRepository<String>() {
 
-    suspend fun saveCode(email: String, code: String, expiry: Duration): Boolean {
-        return redisTemplate.opsForValue().set(getKey(email), code, expiry).awaitSingleOrNull() ?: false
-    }
+    override val keyPrefix = "verificationCode:"
 
-    suspend fun findCodeByEmail(email: String): String? {
-        return redisTemplate.opsForValue().get(getKey(email)).awaitSingleOrNull()
-    }
-
-    // 6. 메서드 이름도 역할에 맞게 변경합니다. (로직은 동일)
-    suspend fun deleteCodeByEmail(email: String) {
-        redisTemplate.opsForValue().delete(getKey(email)).awaitSingleOrNull()
-    }
+    suspend fun saveCode(email: String, code: String, expiry: Duration) = save(email, code, expiry)
+    suspend fun findCodeByEmail(email: String) = find(email)
+    suspend fun deleteByEmail(email: String) = delete(email)
 }

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
@@ -1,19 +1,17 @@
 package com.example.solo_play_web_server.auth.service
 
-import com.example.solo_play_web_server.auth.dto.EmailAvailabilityResponse
-import com.example.solo_play_web_server.auth.dto.EmailVerificationRequest
-import com.example.solo_play_web_server.auth.dto.LoginRequest
-import com.example.solo_play_web_server.auth.dto.SignUpRequest
-import com.example.solo_play_web_server.auth.dto.TokenResponse
+import com.example.solo_play_web_server.auth.dto.*
 import com.example.solo_play_web_server.auth.entity.Member
 import com.example.solo_play_web_server.auth.enum.AuthProvider
 import com.example.solo_play_web_server.auth.enum.MemberRole
 import com.example.solo_play_web_server.auth.repository.MemberRepository
+import com.example.solo_play_web_server.auth.repository.PendingMemberRepository
 import com.example.solo_play_web_server.auth.repository.VerificationCodeRepository
 import com.example.solo_play_web_server.common.auth.JwtProvider
 import com.example.solo_play_web_server.common.exception.EmailDuplicateException
 import com.example.solo_play_web_server.common.exception.InvalidTokenException
 import com.example.solo_play_web_server.common.exception.LoginFailedException
+import com.example.solo_play_web_server.common.exception.VerificationCodeException
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -28,47 +26,60 @@ class MemberService (
     private val passwordEncoder : PasswordEncoder,
     private val verificationCodeRepository: VerificationCodeRepository,
     private val emailService : EmailService,
-    private val jwtProvider: JwtProvider
+    private val jwtProvider: JwtProvider,
+    private val pendingMemberRepository: PendingMemberRepository
 ){
     @Transactional(readOnly = true)
     suspend fun isEmailAlreadyExists(email: String): Boolean {
         return memberRepository.existsByEmail(email).awaitSingle()
     }
 
-    suspend fun sendVerificationCode(request: EmailVerificationRequest) {
-        if (memberRepository.existsByEmail(request.email).awaitSingle()) {
-            throw EmailDuplicateException(message = "이미 사용 중인 이메일입니다.")
+    @Transactional
+    suspend fun provisionalSignUp(provisionalSignUpRequest: ProvisionalSignUpRequest) {
+        if (memberRepository.findByEmail(provisionalSignUpRequest.email).awaitSingleOrNull() != null) {
+            throw EmailDuplicateException("이미 가입된 이메일입니다.")
         }
 
+        val pendingData = PendingMemberData(
+            email = provisionalSignUpRequest.email,
+            encodedPassword = passwordEncoder.encode(provisionalSignUpRequest.password),
+            agreement = provisionalSignUpRequest.agreement
+        )
+        pendingMemberRepository.save(pendingData)
+
         val code = String.format("%06d", Random().nextInt(1_000_000))
-        val success = verificationCodeRepository.saveCode(request.email, code, Duration.ofMinutes(10))
+
+        val success = verificationCodeRepository.saveCode(provisionalSignUpRequest.email, code, Duration.ofMinutes(10))
 
         if (success) {
-            emailService.sendVerificationCode(request.email, code)
+            emailService.sendVerificationCode(provisionalSignUpRequest.email, code)
         } else {
-            throw RuntimeException("인증 코드 저장에 실패했습니다.")
+            throw RuntimeException("인증 코드 저장에 실패했습니다. 잠시 후 다시 시도해주세요.")
         }
     }
 
-    suspend fun signUp(request: SignUpRequest): TokenResponse {
-        val savedCode = verificationCodeRepository.findCodeByEmail(request.email)
+    @Transactional
+    suspend fun finalizeSignUp(finalizeSignUpRequest: FinalizeSignUpRequest): TokenResponse {
+        val savedCode = verificationCodeRepository.findCodeByEmail(finalizeSignUpRequest.email)
             ?: throw InvalidTokenException("인증 코드가 만료되었거나 유효하지 않습니다.")
-
-        if (savedCode != request.code) {
+        if (savedCode != finalizeSignUpRequest.code) {
             throw InvalidTokenException("인증 코드가 일치하지 않습니다.")
         }
 
+        val pendingData = pendingMemberRepository.findByEmail(finalizeSignUpRequest.email)
+            ?: throw VerificationCodeException("회원가입 시간이 만료되었거나 유효하지 않은 요청입니다.")
+
         val member = Member(
-            email = request.email,
-            password = passwordEncoder.encode(request.password),
-            agreement = request.agreement,
+            email = pendingData.email,
+            password = pendingData.encodedPassword,
+            agreement = pendingData.agreement,
             provider = AuthProvider.LOCAL,
             role = setOf(MemberRole.USER)
         )
-
         val savedMember = memberRepository.save(member).awaitSingle()
 
-        verificationCodeRepository.deleteCodeByEmail(request.email)
+        pendingMemberRepository.deleteByEmail(finalizeSignUpRequest.email)
+        verificationCodeRepository.deleteByEmail(finalizeSignUpRequest.email)
 
         return jwtProvider.generateTokens(savedMember.id!!, savedMember.role)
     }

--- a/src/main/kotlin/com/example/solo_play_web_server/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/common/config/RedisConfig.kt
@@ -1,10 +1,10 @@
 package com.example.solo_play_web_server.common.config
 
+import com.example.solo_play_web_server.auth.dto.PendingMemberData
 import com.example.solo_play_web_server.auth.entity.RefreshToken
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory
@@ -16,15 +16,33 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 @Configuration
 class RedisConfig {
     @Bean
-    @Qualifier("verificationCodeRedisTemplate")
+    fun redisObjectMapper(): ObjectMapper {
+        return ObjectMapper().apply {
+            registerModule(KotlinModule.Builder().build())
+            registerModule(JavaTimeModule())
+        }
+    }
+
+    @Bean("verificationCodeRedisTemplate")
     fun verificationCodeRedisTemplate(factory: ReactiveRedisConnectionFactory): ReactiveRedisTemplate<String, String> {
         val serializer = StringRedisSerializer.UTF_8
         val serializationContext = RedisSerializationContext
-            .newSerializationContext<String, String>()
-            .key(serializer)
-            .value(serializer)
-            .hashKey(serializer)
-            .hashValue(serializer)
+            .newSerializationContext<String, String>(serializer)
+            .build()
+        return ReactiveRedisTemplate(factory, serializationContext)
+    }
+
+    @Bean("pendingMemberDataRedisTemplate")
+    fun pendingMemberDataRedisTemplate(
+        factory: ReactiveRedisConnectionFactory,
+        objectMapper: ObjectMapper
+    ): ReactiveRedisTemplate<String, PendingMemberData> {
+        val keySerializer = StringRedisSerializer.UTF_8
+        val valueSerializer = Jackson2JsonRedisSerializer(objectMapper, PendingMemberData::class.java)
+
+        val serializationContext = RedisSerializationContext
+            .newSerializationContext<String, PendingMemberData>(keySerializer)
+            .value(valueSerializer)
             .build()
 
         return ReactiveRedisTemplate(factory, serializationContext)

--- a/src/main/kotlin/com/example/solo_play_web_server/common/exception/BusinessException.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/common/exception/BusinessException.kt
@@ -6,3 +6,5 @@ open class BusinessException(override val message: String) : RuntimeException(me
 class EmailDuplicateException(message: String) : BusinessException(message)
 class LoginFailedException(message: String) : BusinessException(message)
 class InvalidTokenException(message: String) : BusinessException(message)
+class VerificationCodeException(message: String) : BusinessException(message)
+class SignUpSessionException(message: String) : BusinessException(message)

--- a/src/main/kotlin/com/example/solo_play_web_server/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/common/exception/GlobalExceptionHandler.kt
@@ -49,6 +49,8 @@ class GlobalExceptionHandler {
         val status = when (ex) {
             is EmailDuplicateException -> HttpStatus.CONFLICT
             is LoginFailedException -> HttpStatus.UNAUTHORIZED
+            is VerificationCodeException -> HttpStatus.BAD_REQUEST
+            is SignUpSessionException -> HttpStatus.BAD_REQUEST
             else -> HttpStatus.BAD_REQUEST // 400
         }
         return ResponseEntity.status(status).body(response)

--- a/src/main/kotlin/com/example/solo_play_web_server/common/repository/AbstractRedisRepository.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/common/repository/AbstractRedisRepository.kt
@@ -1,0 +1,24 @@
+package com.example.solo_play_web_server.common.repository
+
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import java.time.Duration
+
+abstract class AbstractRedisRepository<V : Any> {
+    abstract val redisTemplate: ReactiveRedisTemplate<String, V>
+    abstract val keyPrefix: String
+
+    protected fun getKey(keySuffix: String) = "$keyPrefix$keySuffix"
+
+    protected suspend fun save(keySuffix: String, value: V, expiry: Duration): Boolean {
+        return redisTemplate.opsForValue().set(getKey(keySuffix), value, expiry).awaitSingleOrNull() ?: false
+    }
+
+    protected suspend fun find(keySuffix: String): V? {
+        return redisTemplate.opsForValue().get(getKey(keySuffix)).awaitSingleOrNull()
+    }
+
+    protected suspend fun delete(keySuffix: String): Boolean {
+        return redisTemplate.opsForValue().delete(getKey(keySuffix)).awaitSingleOrNull() ?: false
+    }
+}


### PR DESCRIPTION
## Description
### 1. 회원가입 API 분리
기존의 단일 API였던 회원가입 로직을 사용자 경험 및 안정성 개선을 위해 아래 두 단계로 분리했습니다.

- 1단계 (임시 가입): POST /api/auth/signup/provisional - 회원 정보를 받아 Redis에 임시 저장하고 인증 이메일을 발송합니다.

- 2단계 (최종 가입): POST /api/auth/signup/finalize - 인증 코드를 검증하여 최종 회원가입을 완료하고 토큰을 발급합니다.

### 2. Redis Repository 리팩토링
회원가입 과정에서 사용되는 VerificationCodeRepository와 PendingMemberRepository의 중복 코드를 AbstractRedisRepository로 추상화하여 코드의 재사용성과 유지보수성을 향상시켰습니다.

---

## Key Code (before, after)
1. 회원가입 API 분리 (`MemberController.kt`)
```kotlin
// Before: 단일 회원가입 API
@PostMapping("/signup")
suspend fun signUp(@Valid @RequestBody signUpRequest: SignUpRequest): ResponseEntity<...> { 
    // 인증코드 검증과 회원 생성을 한번에 처리
}

// After: 두 개의 API로 역할 분리
@PostMapping("/signup/provisional")
suspend fun provisionalSignUp(@Valid @RequestBody request: ProvisionalSignUpRequest): ResponseEntity<...> {
    // 임시 정보 저장 및 이메일 발송
}

@PostMapping("/signup/finalize")
suspend fun finalizeSignUp(@Valid @RequestBody request: FinalizeSignUpRequest): ResponseEntity<...> {
    // 인증코드 검증 및 최종 가입
}
```

### 2. Redis Repository 리팩토링 (`PendingMemberRepository.kt`)
```kotlin
// Before: Repository 내부에 Redis 로직이 모두 존재
@Repository
class PendingMemberRepository(...) {
    private val PENDING_SIGNUP_PREFIX = "PENDING_SIGNUP:"
    suspend fun save(...) {
        redisTemplate.opsForValue().set(...).awaitSingleOrNull()
    }
    // ... findByEmail, deleteByEmail 구현 ...
}

// After: 공통 로직을 추상 클래스로 분리하여 코드 간소화
@Repository
class PendingMemberRepository(...) : AbstractRedisRepository<PendingMemberData>() {
    override val keyPrefix = "PENDING_SIGNUP:"
    private val TTL = Duration.ofMinutes(10)

    suspend fun save(pendingMemberData: PendingMemberData) = save(pendingMemberData.email, pendingMemberData, TTL)
    suspend fun findByEmail(email: String) = find(email)
    suspend fun deleteByEmail(email: String) = delete(email)
}
```

---

## Reason for Change
- 사용자 경험 개선: 회원가입 절차를 2단계로 분리하여, 사용자가 이메일 인증을 완료하기 전까지는 정식 회원 데이터가 생성되지 않도록 하여 데이터의 정합성을 높였습니다. 또한 각 단계별로 명확한 피드백을 제공할 수 있습니다.

- 코드 중복 제거 (DRY 원칙): 여러 Redis Repository에 반복되던 데이터 CRUD 로직을 AbstractRedisRepository로 추상화하여 중복을 제거하고 코드의 양을 줄였습니다.

- 유지보수성 및 확장성 향상: 역할과 책임이 명확하게 분리되어 코드 이해가 쉬워졌습니다. 특히 새로운 Redis 기반 Repository를 추가해야 할 때, AbstractRedisRepository를 상속받기만 하면 되므로 확장성이 크게 향상되었습니다.