### PR TITLE
test: PlaceController 통합 테스트 추가 및 설정 값 외부화

### DIFF
--- a/src/test/kotlin/com/example/solo_play_web_server/place/controller/PlaceControllerSpec.kt
+++ b/src/test/kotlin/com/example/solo_play_web_server/place/controller/PlaceControllerSpec.kt
@@ -1,0 +1,80 @@
+package com.example.solo_play_web_server.place.controller
+
+import com.example.solo_play_web_server.place.dto.RecommendPlaceResponse
+import com.example.solo_play_web_server.place.enum.Level
+import com.example.solo_play_web_server.place.service.PlaceService
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.coEvery
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class PlaceControllerSpec(
+    private val webTestClient: WebTestClient,
+
+    @MockkBean
+    private val placeService: PlaceService
+) : BehaviorSpec({
+
+    Given("장소 검색 및 저장 API (GET /api/places)") {
+        val keyword = "카페"
+        val page = 1
+
+        When("유효한 키워드로 요청이 들어오면") {
+            coEvery { placeService.searchAndSavePlacesByKeyword(keyword, page) } returns 5
+
+            val response = webTestClient.get()
+                .uri("/api/places?keyword={keyword}&page={page}", keyword, page)
+                .exchange()
+
+            Then("200 OK와 함께 저장된 장소의 수를 반환한다") {
+                response.expectStatus().isOk
+                    .expectBody()
+                    .jsonPath("$.status").isEqualTo("SUCCESS")
+                    .jsonPath("$.message").isEqualTo("'$keyword' 검색 결과, 5 개의 새로운 장소를 저장했습니다.")
+                    .jsonPath("$.data").isEqualTo(5)
+            }
+        }
+    }
+
+    Given("레벨별 추천 장소 API (GET /api/places/recommendations)") {
+        When("유효한 레벨 파라미터(ONE)로 요청하면") {
+            // Arrange
+            val level = Level.ONE
+            val fakeResponse = listOf(
+                RecommendPlaceResponse(
+                    level = Level.ONE, imageUrl = "url1", displayTitle = "AI가 만든 제목",
+                    placeName = "테스트 추천 카페", area = "마포구", displayTags = listOf("#추천", "#카페")
+                )
+            )
+            coEvery { placeService.getRecommendedPlacesByLevel(level) } returns fakeResponse
+
+            val response = webTestClient.get()
+                .uri("/api/places/recommendations?level=ONE")
+                .exchange()
+
+            Then("200 OK와 함께 추천 장소 DTO 목록을 반환한다") {
+                response.expectStatus().isOk
+                    .expectBody()
+                    .jsonPath("$.status").isEqualTo("SUCCESS")
+                    .jsonPath("$.data").isArray
+                    .jsonPath("$.data[0].placeName").isEqualTo("테스트 추천 카페")
+            }
+        }
+
+        When("잘못된 레벨 파라미터로 요청하면") {
+            val response = webTestClient.get()
+                .uri("/api/places/recommendations?level=INVALID_LEVEL")
+                .exchange()
+
+            Then("500 internalServerError 에러를 반환한다") {
+                response.expectStatus().is5xxServerError
+            }
+        }
+    }
+})

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,18 +1,45 @@
 spring:
-  web:
-    resources:
-      add-mappings: false
-
-  sql:
-    init:
-      mode: always
+  application:
+    name: solo_play_web_server
+  config:
+    import: optional:file:.env[.properties]
 
   data:
-    r2dbc:
-      repositories:
-        enabled: true
+    mongodb:
+      uri: ${MONGO_DB_URL}
 
-  r2dbc:
-    url: r2dbc:h2:mem:///testdb;MODE=MySQL
-    username: sa
-    password:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+
+  mail:
+    protocol: smtp
+    port: 587
+    username: ${GOOGLE_ID}
+    password: ${APP_PASSWORD}
+    host: smtp.gmail.com
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui/index.html
+
+jwt:
+  secret-key: ${JWT_SECRET}
+  access-token-expiry-ms: ${ACCESS_EXPIRY}
+  refresh-token-expiry-ms: ${REFRESH_EXPIRY}
+
+kakao:
+  api:
+    key: ${KAKAO_API_KEY}
+
+gemini:
+  api:
+    key: ${GEMINI_API_KEY}
+    url: ${GEMINI_API_URL}


### PR DESCRIPTION
## Description
컨트롤러 계층의 동작을 검증하기 위해, WebTestClient를 사용한 PlaceController 통합 테스트(PlaceControllerSpec)를 추가했습니다. 이 테스트는 API 엔드포인트의 요청/응답 및 상태 코드가 의도대로 동작하는지 확인합니다.

## Key Code (before, after)
1. `PlaceControllerSpec.kt` - 통합 테스트 코드 신규 추가
```kotlin
// Before:
// No integration tests for PlaceController

// After:
@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
class PlaceControllerSpec(
    private val webTestClient: WebTestClient,
    @MockkBean private val placeService: PlaceService
) : DescribeSpec({
    describe("GET /api/places/recommendations") {
        it("200 OK와 함께 추천 장소 목록을 반환한다") {
            // Arrange
            coEvery { placeService.getRecommendedPlacesByLevel(...) } returns ...

            // Act & Assert
            webTestClient.get().uri("/api/places/recommendations?level=ONE")
                .exchange()
                .expectStatus().isOk
                .expectBody()
                .jsonPath("$.status").isEqualTo("SUCCESS")
        }
    }
})
```

## Reason for Change
- 엔드포인트 동작 보장: PlaceController 통합 테스트를 통해 API의 전체 웹 계층(URL 매핑, DTO 변환, 응답 직렬화, 상태 코드 반환 등)이 명세대로 동작함을 보장하여 안정성을 높였습니다.