### PR TITLE
test: JwtProvider 단위 테스트의 만료 시간 검증 로직 수정

### DIFF
--- a/src/main/kotlin/com/example/solo_play_web_server/common/auth/jwtProvider.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/common/auth/jwtProvider.kt
@@ -26,7 +26,7 @@ class JwtProvider(
     private lateinit var key: Key
 
     @PostConstruct
-    protected fun init() {
+    internal fun init() {
         // secretKey를 HMAC-SHA 키 객체로 변환
         key = Keys.hmacShaKeyFor(secretKey.toByteArray(StandardCharsets.UTF_8))
     }

--- a/src/test/kotlin/com/example/solo_play_web_server/common/auth/JwtProviderSpec.kt
+++ b/src/test/kotlin/com/example/solo_play_web_server/common/auth/JwtProviderSpec.kt
@@ -1,0 +1,60 @@
+package com.example.solo_play_web_server.common.auth
+
+import com.example.solo_play_web_server.auth.enum.MemberRole
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.date.shouldBeBetween
+import java.nio.charset.StandardCharsets
+import java.util.*
+
+class JwtProviderSpec : BehaviorSpec({
+
+    val testSecretKey = "a-very-long-and-secure-secret-key-for-testing-purpose-only"
+    val accessTokenExpiryMs = 3600000L // 1시간
+    val refreshTokenExpiryMs = 86400000L // 24시간
+
+    val jwtProvider = JwtProvider(
+        secretKey = testSecretKey,
+        accessTokenExpiryMs = accessTokenExpiryMs,
+        refreshTokenExpiryMs = refreshTokenExpiryMs
+    ).apply { init() }
+
+    val testKey = Keys.hmacShaKeyFor(testSecretKey.toByteArray(StandardCharsets.UTF_8))
+
+    Given("JwtProvider가 토큰을 생성할 때") {
+        val userId = "user-id-123"
+        val roles = setOf(MemberRole.USER)
+
+        When("사용자 ID와 역할을 전달하면") {
+            val now = Date()
+            val tokens = jwtProvider.generateTokens(userId, roles)
+
+            Then("액세스 토큰이 유효하고 올바른 만료 시간을 가져야 한다") {
+                val claims = Jwts.parser().verifyWith(testKey).build()
+                    .parseSignedClaims(tokens.accessToken).payload
+
+                val actualExpiry = claims.expiration.toInstant()
+                val expectedExpiry = Date(now.time + accessTokenExpiryMs)
+
+                val lowerBound = Date(expectedExpiry.time - 1000).toInstant()
+                val upperBound = Date(expectedExpiry.time + 1000).toInstant()
+
+                actualExpiry.shouldBeBetween(lowerBound, upperBound)
+            }
+
+            Then("리프레시 토큰이 유효하고 올바른 만료 시간을 가져야 한다") {
+                val claims = Jwts.parser().verifyWith(testKey).build()
+                    .parseSignedClaims(tokens.refreshToken).payload
+
+                val actualExpiry = claims.expiration.toInstant()
+                val expectedExpiry = Date(now.time + refreshTokenExpiryMs)
+
+                val lowerBound = Date(expectedExpiry.time - 1000).toInstant()
+                val upperBound = Date(expectedExpiry.time + 1000).toInstant()
+
+                actualExpiry.shouldBeBetween(lowerBound, upperBound)
+            }
+        }
+    }
+})

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,36 +1,40 @@
 spring:
   application:
-    name: solo_play_web_server
-  config:
-    import: optional:file:.env[.properties]
+    name: solo_play_web_server-test
 
   data:
     mongodb:
-      uri: ${MONGO_DB_URL}
+      uri: mongodb://localhost:27017/soloplay_test_db
 
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
+      host: localhost
+      port: 6379
 
   mail:
-    protocol: smtp
+    host: smtp.test.com
     port: 587
-    username: ${GOOGLE_ID}
-    password: ${APP_PASSWORD}
-    host: smtp.gmail.com
+    username: test-user@test.com
+    password: test-password
     properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
+      mail.smtp.auth: true
+      starttls.enable: true
 
 springdoc:
+  api-docs:
+    enabled: false
   swagger-ui:
-    path: /swagger-ui/index.html
+    enabled: false
 
 jwt:
-  secret-key: ${JWT_SECRET}
-  access-token-expiry-ms: ${ACCESS_EXPIRY}
-  refresh-token-expiry-ms: ${REFRESH_EXPIRY}
+  secret-key: "a-very-long-and-secure-secret-key-for-testing-purpose-only-1234567890"
+  access-token-expiry-ms: 3600000   # 1시간
+  refresh-token-expiry-ms: 86400000  # 24시간
+
+kakao:
+  api:
+    key: "test-kakao-api-key"
+
+gemini:
+  api:
+    key: "test-gemini-api-key"
+    url: "http://localhost/gemini"


### PR DESCRIPTION
## Description
테스트 실행 환경의 안정성과 예측 가능성을 확보하기 위해, src/test/resources/application.yml 파일을 생성하여 테스트 전용 설정을 분리했습니다. 이를 통해 테스트는 더 이상 외부 환경 변수에 의존하지 않고, 실제 개발 DB에 영향을 주지 않는 격리된 환경에서 실행됩니다.

또한, JwtProviderSpec에서 토큰 만료 시간을 검증하는 로직을, 허용 오차 범위를 고려하는 shouldBeBetween을 사용하도록 수정하여 테스트의 정확도와 안정성을 높였습니다.

## Key Code (before, after)
1. 테스트 환경 설정 분리 (`application.yml`)

```yaml
## Before: 테스트 실행 시 src/main/resources/application.yml에 의존
// CI/CD 환경 변수가 없으면 테스트 실패 가능성이 존재
spring:
  data:
    mongodb:
      uri: ${MONGO_DB_URL}
jwt:
  secret-key: ${JWT_SECRET}

## After: src/test/resources/application.yml에 테스트 전용 설정 추가
## 테스트는 항상 아래의 고정된 값으로 실행되어 안정성 확보
spring:
  application:
    name: solo_play_web_server-test
  data:
    mongodb:
      uri: mongodb://localhost:27017/soloplay_test_db
jwt:
  secret-key: "a-very-long-and-secure-secret-key-for-testing-purpose-only"
  access-token-expiry-ms: 3600000
```

2. `JwtProviderSpec` 만료 시간 검증 로직 수정

```kotlin
// Before: 부정확하고 실패 가능성이 있는 시간 검증
val now = Date()
// ... 토큰 생성
val claims = Jwts.parser()...parseSignedClaims(tokens.accessToken).payload
claims.expiration shouldBeAfter now // 단순 미래 시점인지만 확인

// After: 허용 오차를 고려한 정확한 범위 검증
val now = Date()
val tokens = jwtProvider.generateTokens(...)
val claims = Jwts.parser()...parseSignedClaims(tokens.accessToken).payload

val actualExpiry = claims.expiration.toInstant()
val expectedExpiry = Date(now.time + accessTokenExpiryMs)

// 실행 시간에 따른 약간의 오차(+-1초)를 허용하는 범위 생성
val lowerBound = Date(expectedExpiry.time - 1000).toInstant()
val upperBound = Date(expectedExpiry.time + 1000).toInstant()

actualExpiry.shouldBeBetween(lowerBound, upperBound) // 범위 안에 있는지 검증
```

## Reason for Change
- 테스트 안정성 확보: System.currentTimeMillis()나 new Date()는 호출 시점마다 미세하게 달라져 정확한 시간 일치 비교(shouldBe)는 테스트를 불안정하게 만듭니다. shouldBeBetween을 사용하여 오차 범위를 허용함으로써 안정적이고 신뢰도 높은 테스트를 구축했습니다.

- 타입 불일치 문제 해결: java.util.Date를 직접 지원하지 않는 Kotest 검증 구문을 사용하기 위해, 최신 java.time.Instant 타입으로 변환하여 비교하도록 수정했습니다.