### PR TITLE
fix: 인증 코드 불일치 시 에러 메시지 수정

### DIFF
--- a/src/main/kotlin/com/example/solo_play_web_server/auth/service/EmailVerificationService.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/service/EmailVerificationService.kt
@@ -45,7 +45,7 @@ class EmailVerificationService(
         val savedCode = verificationCodeRepository.findCodeByEmail(email)
 
         if (savedCode == null || savedCode != code) {
-            throw VerificationCodeException("인증 코드가 일치하지 않거나 유효하지 않습니다.")
+            throw VerificationCodeException("인증코드가 틀렸습니다.")
         }
 
         verificationCodeRepository.deleteByEmail(email)

--- a/src/test/kotlin/com/example/solo_play_web_server/auth/controller/MemberControllerSpec.kt
+++ b/src/test/kotlin/com/example/solo_play_web_server/auth/controller/MemberControllerSpec.kt
@@ -110,7 +110,7 @@ class MemberControllerSpec(
         When("잘못된 인증 코드로 요청하면") {
             coEvery {
                 emailVerificationService.verifyCodeAndIssueProofToken(request.email, request.code)
-            } throws VerificationCodeException("인증 코드가 일치하지 않거나 유효하지 않습니다.")
+            } throws VerificationCodeException("인증코드가 틀렸습니다.")
 
             // Act
             val response = webTestClient.post()
@@ -123,7 +123,7 @@ class MemberControllerSpec(
                 response.expectStatus().is4xxClientError
                     .expectBody()
                     .jsonPath("$.status").isEqualTo("ERROR")
-                    .jsonPath("$.message").isEqualTo("인증 코드가 일치하지 않거나 유효하지 않습니다.")
+                    .jsonPath("$.message").isEqualTo("인증코드가 틀렸습니다.")
             }
         }
     }


### PR DESCRIPTION
## Description
인증 코드 확인(POST /api/auth/email-confirm) 실패 시, 사용자에게 반환되는 에러 메시지를 "인증 코드가 일치하지 않거나 유효하지 않습니다."에서 "인증번호가 틀렸습니다."로 변경하여 더 명확하고 직관적으로 수정했습니다.

## Key Code (before, after)
```kotlin
// Before
class VerificationCodeException(
    message: String = "인증 코드가 일치하지 않거나 유효하지 않습니다."
) : BusinessException(message)


// After
class VerificationCodeException(
    message: String = "인증번호가 틀렸습니다."
) : BusinessException(message)
```