### PR TITLE
feat: 로그아웃 기능 추가 및 로그인 시 Refresh Token 저장 로직 구현

### DIFF
--- a/src/main/kotlin/com/example/solo_play_web_server/auth/controller/MemberController.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/controller/MemberController.kt
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.User
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -93,5 +95,14 @@ class MemberController(
         val tokenResponse = memberService.login(loginRequest)
         return ResponseEntity.status(HttpStatus.OK)
             .body(ApiResponse(status = ResultStatus.SUCCESS, message = "로그인에 성공했습니다.", data = tokenResponse))
+    }
+
+    @Operation(summary = "[logout] 로그아웃", description = "서버에 저장된 리프레시 토큰을 삭제하여 현재 세션을 무효화합니다.")
+    @PostMapping("/logout")
+    suspend fun logout(
+        @AuthenticationPrincipal user: User
+    ): ResponseEntity<ApiResponse<Unit>> {
+        memberService.logout(user.username)
+        return ResponseEntity.ok(ApiResponse(status = ResultStatus.SUCCESS, message = "로그아웃되었습니다."))
     }
 }

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/repository/RefreshTokenRepository.kt
@@ -1,9 +1,26 @@
 package com.example.solo_play_web_server.auth.repository
 
 import com.example.solo_play_web_server.auth.entity.RefreshToken
-import reactor.core.publisher.Mono
+import com.example.solo_play_web_server.common.repository.AbstractRedisRepository
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.stereotype.Repository
+import java.time.Duration
 
-interface RefreshTokenRepository {
-    fun save(refreshToken: RefreshToken): Mono<RefreshToken>
-    fun findByUserId(userId: Long): Mono<RefreshToken>
+@Repository
+class RefreshTokenRepository(
+    @Qualifier("refreshTokenRedisTemplate")
+    override val redisTemplate: ReactiveRedisTemplate<String, RefreshToken>,
+
+    @Value("\${jwt.refresh-token-expiry-ms}")
+    private val refreshTokenExpiryMs: Long
+) : AbstractRedisRepository<RefreshToken>() {
+
+    override val keyPrefix = "refreshToken:"
+    private val TTL: Duration get() = Duration.ofMillis(refreshTokenExpiryMs)
+
+    suspend fun save(refreshToken: RefreshToken) = save(refreshToken.userId, refreshToken, TTL)
+    suspend fun findByUserId(userId: String) = find(userId)
+    suspend fun deleteByUserId(userId: String) = delete(userId)
 }

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/repository/RefreshTokenRepository.kt
@@ -20,7 +20,14 @@ class RefreshTokenRepository(
     override val keyPrefix = "refreshToken:"
     private val TTL: Duration get() = Duration.ofMillis(refreshTokenExpiryMs)
 
-    suspend fun save(refreshToken: RefreshToken) = save(refreshToken.userId, refreshToken, TTL)
+    suspend fun save(userId: String, token: String) {
+        val refreshToken = RefreshToken(
+            userId = userId,
+            token = token,
+            expiry = refreshTokenExpiryMs / 1000
+        )
+        save(userId, refreshToken, TTL)
+    }
     suspend fun findByUserId(userId: String) = find(userId)
     suspend fun deleteByUserId(userId: String) = delete(userId)
 }

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
@@ -4,7 +4,6 @@ import com.example.solo_play_web_server.auth.dto.LoginRequest
 import com.example.solo_play_web_server.auth.dto.SignUpRequest
 import com.example.solo_play_web_server.auth.dto.TokenResponse
 import com.example.solo_play_web_server.auth.entity.Member
-import com.example.solo_play_web_server.auth.entity.RefreshToken
 import com.example.solo_play_web_server.auth.enum.AuthProvider
 import com.example.solo_play_web_server.auth.enum.MemberRole
 import com.example.solo_play_web_server.auth.repository.MemberRepository
@@ -26,7 +25,7 @@ class MemberService (
     private val memberRepository : MemberRepository,
     private val passwordEncoder : PasswordEncoder,
     private val jwtProvider: JwtProvider,
-    private val refreshTokenRepository: RefreshTokenRepository
+    private val refreshTokenRepository: RefreshTokenRepository,
     private val signUpProofRepository: SignUpProofRepository
 ){
     @Transactional(readOnly = true)
@@ -71,5 +70,9 @@ class MemberService (
         )
 
         return tokens
+    }
+
+    suspend fun logout(userId: String) {
+        refreshTokenRepository.deleteByUserId(userId)
     }
 }

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
@@ -8,6 +8,7 @@ import com.example.solo_play_web_server.auth.entity.RefreshToken
 import com.example.solo_play_web_server.auth.enum.AuthProvider
 import com.example.solo_play_web_server.auth.enum.MemberRole
 import com.example.solo_play_web_server.auth.repository.MemberRepository
+import com.example.solo_play_web_server.auth.repository.RefreshTokenRepository
 import com.example.solo_play_web_server.auth.repository.SignUpProofRepository
 import com.example.solo_play_web_server.common.auth.JwtProvider
 import com.example.solo_play_web_server.common.exception.EmailDuplicateException
@@ -25,6 +26,7 @@ class MemberService (
     private val memberRepository : MemberRepository,
     private val passwordEncoder : PasswordEncoder,
     private val jwtProvider: JwtProvider,
+    private val refreshTokenRepository: RefreshTokenRepository
     private val signUpProofRepository: SignUpProofRepository
 ){
     @Transactional(readOnly = true)
@@ -63,12 +65,10 @@ class MemberService (
 
         val tokens = jwtProvider.generateTokens(member.id!!, member.role)
 
-        val refreshToken = RefreshToken(
-            userId = member.id!!,
-            token = tokens.refreshToken,
-            expiry = refreshTokenExpiryMs / 1000
+        refreshTokenRepository.save(
+            userId = member.id,
+            token = tokens.refreshToken
         )
-        refreshTokenRepository.save(refreshToken)
 
         return tokens
     }

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
@@ -4,6 +4,7 @@ import com.example.solo_play_web_server.auth.dto.LoginRequest
 import com.example.solo_play_web_server.auth.dto.SignUpRequest
 import com.example.solo_play_web_server.auth.dto.TokenResponse
 import com.example.solo_play_web_server.auth.entity.Member
+import com.example.solo_play_web_server.auth.entity.RefreshToken
 import com.example.solo_play_web_server.auth.enum.AuthProvider
 import com.example.solo_play_web_server.auth.enum.MemberRole
 import com.example.solo_play_web_server.auth.repository.MemberRepository
@@ -54,12 +55,21 @@ class MemberService (
 
     suspend fun login(loginRequest: LoginRequest) : TokenResponse {
         val member = memberRepository.findByEmail(loginRequest.email).awaitSingleOrNull()
-            ?: throw LoginFailedException("존재하지 않는 계정입니다. 회원가입 하시겠습니까?")
+            ?: throw LoginFailedException("존재하지 않는 계정입니다.")
 
         if (!passwordEncoder.matches(loginRequest.password, member.password)) {
             throw LoginFailedException("사용자 이름 또는 비밀번호가 올바르지 않습니다.")
         }
 
-        return jwtProvider.generateTokens(member.id!!, member.role)
+        val tokens = jwtProvider.generateTokens(member.id!!, member.role)
+
+        val refreshToken = RefreshToken(
+            userId = member.id!!,
+            token = tokens.refreshToken,
+            expiry = refreshTokenExpiryMs / 1000
+        )
+        refreshTokenRepository.save(refreshToken)
+
+        return tokens
     }
 }

--- a/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
+++ b/src/main/kotlin/com/example/solo_play_web_server/auth/service/MemberService.kt
@@ -56,7 +56,7 @@ class MemberService (
 
     suspend fun login(loginRequest: LoginRequest) : TokenResponse {
         val member = memberRepository.findByEmail(loginRequest.email).awaitSingleOrNull()
-            ?: throw LoginFailedException("존재하지 않는 계정입니다.")
+            ?: throw LoginFailedException("존재하지 않는 계정입니다. 회원가입 하시겠습니까?")
 
         if (!passwordEncoder.matches(loginRequest.password, member.password)) {
             throw LoginFailedException("사용자 이름 또는 비밀번호가 올바르지 않습니다.")

--- a/src/test/kotlin/com/example/solo_play_web_server/auth/service/MemberServiceSpec.kt
+++ b/src/test/kotlin/com/example/solo_play_web_server/auth/service/MemberServiceSpec.kt
@@ -5,6 +5,7 @@ import com.example.solo_play_web_server.auth.entity.Member
 import com.example.solo_play_web_server.auth.enum.AuthProvider
 import com.example.solo_play_web_server.auth.enum.MemberRole
 import com.example.solo_play_web_server.auth.repository.MemberRepository
+import com.example.solo_play_web_server.auth.repository.RefreshTokenRepository
 import com.example.solo_play_web_server.auth.repository.SignUpProofRepository
 import com.example.solo_play_web_server.common.auth.JwtProvider
 import com.example.solo_play_web_server.common.exception.LoginFailedException
@@ -27,6 +28,8 @@ class MemberServiceSpec : BehaviorSpec() {
     lateinit var jwtProvider: JwtProvider
     @MockK
     lateinit var signUpProofRepository: SignUpProofRepository
+    @MockK
+    lateinit var refreshTokenRepository: RefreshTokenRepository
 
     @InjectMockKs
     lateinit var memberService: MemberService
@@ -90,10 +93,14 @@ class MemberServiceSpec : BehaviorSpec() {
                 every { passwordEncoder.matches(loginRequest.password, member.password) } returns true
                 every { jwtProvider.generateTokens(member.id!!, member.role) } returns tokenResponse
 
+                coEvery { refreshTokenRepository.save(any(), any()) } just runs
+
                 val result = memberService.login(loginRequest)
 
-                Then("성공적으로 로그인이되고 토큰이 발급된다."){
+                Then("성공적으로 로그인이 되고 토큰이 발급되며, Refresh Token이 저장된다"){
                     result shouldBe tokenResponse
+
+                    coVerify(exactly = 1) { refreshTokenRepository.save(member.id!!, tokenResponse.refreshToken) }
                 }
             }
 
@@ -121,4 +128,6 @@ class MemberServiceSpec : BehaviorSpec() {
             }
         }
     }
+
+
 }

--- a/src/test/kotlin/com/example/solo_play_web_server/auth/service/MemberServiceSpec.kt
+++ b/src/test/kotlin/com/example/solo_play_web_server/auth/service/MemberServiceSpec.kt
@@ -127,7 +127,19 @@ class MemberServiceSpec : BehaviorSpec() {
                 }
             }
         }
+
+        Given("로그아웃(logout) 시") {
+            val userId = "user-id-123"
+
+            When("사용자 ID로 로그아웃을 요청하면") {
+                coEvery { refreshTokenRepository.deleteByUserId(userId) } returns true
+
+                memberService.logout(userId)
+
+                Then("해당 사용자의 Refresh Token이 삭제된다") {
+                    coVerify(exactly = 1) { refreshTokenRepository.deleteByUserId(userId) }
+                }
+            }
+        }
     }
-
-
 }


### PR DESCRIPTION
## Description
더 안전한 인증 시스템을 구축하기 위해 로그아웃 기능을 추가하고, 로그인 시 Refresh Token을 서버(Redis)에 저장하도록 로직을 개선했습니다.

1. 로그인: login 성공 시, 발급된 Refresh Token을 Redis에 저장하여 서버가 토큰을 관리하도록 변경했습니다.

2. 로그아웃: POST /api/auth/logout API를 추가했습니다. 이 API는 Redis에 저장된 Refresh Token을 삭제하여, 해당 토큰으로 더 이상 새로운 Access Token을 발급받지 못하도록 세션을 무효화합니다.

또한, 이 두 가지 기능 변경에 맞춰 MemberService의 단위 테스트 코드(MemberServiceSpec)를 수정 및 추가하여 코드의 안정성을 확보했습니다.

## Key Code (before, after)
`MemberService.kt` - login 메서드 수정 및 logout 메서드 추가
```kotlin
// Before: login
suspend fun login(loginRequest: LoginRequest) : TokenResponse {
    // ... 사용자 검증 ...
    // 토큰 발급 후 바로 반환
    return jwtProvider.generateTokens(member.id!!, member.role)
}

// After: login & logout
suspend fun login(loginRequest: LoginRequest) : TokenResponse {
    // ... 사용자 검증 ...
    val tokens = jwtProvider.generateTokens(member.id!!, member.role)

    // ◀️ Refresh Token을 Redis에 저장하는 로직 추가
    val refreshToken = RefreshToken(...)
    refreshTokenRepository.save(refreshToken)

    return tokens
}

/**
 * 로그아웃 메서드 신규 추가
 */
suspend fun logout(userId: String) {
    refreshTokenRepository.deleteByUserId(userId)
}
```

`MemberServiceSpec.kt` - 테스트 코드 수정 및 추가
```kotlin
// Before: login 테스트
Then("성공적으로 로그인이되고 토큰이 발급된다.") {
    result shouldBe tokenResponse // 반환값만 검증
}

// After: login 테스트
Then("...Refresh Token이 저장된다") {
    result shouldBe tokenResponse
    // Refresh Token 저장 행위 검증 추가
    coVerify(exactly = 1) { refreshTokenRepository.save(any(), any()) }
}

// After: logout 테스트 신규 추가
Given("로그아웃(logout) 시") {
    When("사용자 ID로 로그아웃을 요청하면") {
        // ...
        Then("해당 사용자의 Refresh Token이 삭제된다") {
            coVerify(exactly = 1) { refreshTokenRepository.deleteByUserId(userId) }
        }
    }
}
```

## Reason for Change
- 보안 강화: 서버가 Refresh Token의 유효성을 직접 관리(저장 및 삭제)하게 함으로써, 토큰이 탈취되더라도 강제로 세션을 무효화할 수 있는 로그아웃 기능을 구현했습니다. 이는 Stateless한 JWT의 단점을 보완하는 표준적인 방법입니다.

- 안정적인 세션 관리: 로그인 시마다 Refresh Token을 Redis에 저장하고, 로그아웃 시 삭제하는 명확한 세션 생명주기를 구축했습니다.

- 테스트 커버리지 확보: 변경 및 추가된 login, logout 비즈니스 로직에 대한 단위 테스트를 작성하여 코드의 안정성과 신뢰도를 높였습니다.