### PR TITLE
chore: docker-compose에 외부 API 환경변수 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,10 @@ services:
       GOOGLE_ID: ${GOOGLE_ID}
       APP_PASSWORD: ${APP_PASSWORD}
 
+      KAKAO_API_KEY: ${KAKAO_API_KEY}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
+      GEMINI_API_URL: ${GEMINI_API_URL}
+
     depends_on:
       - mongodb
       - redis


### PR DESCRIPTION
## Description
docker-compose 환경에서 KakaoApiService와 PlaceEnrichmentService가 정상적으로 동작하기 위해 필요한 환경 변수가 누락되어 있었습니다.

KAKAO_API_KEY, GEMINI_API_KEY, GEMINI_API_URL 환경 변수를 docker-compose.yml 파일에 추가하여, 컨테이너 실행 시 외부 .env 파일로부터 값을 주입받을 수 있도록 수정했습니다.